### PR TITLE
torbulkexitlist/go: upgrade go to 1.21

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -12,7 +12,7 @@ jobs:
 
       - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
 
       - run: go run .
 

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.20.3
+golang 1.21.3

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/pomerium/torbulkexitlist
 
-go 1.20
+go 1.21


### PR DESCRIPTION
For https://github.com/pomerium/internal/issues/1519